### PR TITLE
Added support for the UK variant of Lidl Powerstrip

### DIFF
--- a/zigbee-multi-switch-Zemismart/fingerprints.yml
+++ b/zigbee-multi-switch-Zemismart/fingerprints.yml
@@ -14,3 +14,8 @@ zigbeeManufacturer:
     manufacturer: 3A Smart Home DE
     model: LXN-2S27LX1.0
     deviceProfileName: two-switch
+  - id: "LIDL/TS011F-UK"
+    deviceLabel: Lidl MultiPlug
+    manufacturer: _TZ3000_vmpbygs5
+    model: TS011F
+    deviceProfileName: three-outlet

--- a/zigbee-multi-switch-Zemismart/src/init.lua
+++ b/zigbee-multi-switch-Zemismart/src/init.lua
@@ -97,7 +97,7 @@ local function on_off_attr_handler(self, device, value, zb_rx)
   local attr_value = value.value
   if src_endpoint == ep_ini then
    --- Detect general button pressed in lidl strip device
-   if device:get_manufacturer() == "_TZ3000_1obwwnmq" then
+   if device:get_manufacturer() == "_TZ3000_1obwwnmq" or device:get_manufacturer() == "_TZ3000_vmpbygs5" then
     device:send(zcl_clusters.OnOff.attributes.OnOff:read(device):to_endpoint (ep_ini + 1))
     device:send(zcl_clusters.OnOff.attributes.OnOff:read(device):to_endpoint (ep_ini + 2))
    end 


### PR DESCRIPTION
Hi,

I have added the fingerprint for the UK variant of the lidl powerstrip as it has a slightly different manufacturer name - but otherwise everything seems to work the same.

I have changed the fingerprint file, and also the line in the code that forces a status update of plugs 2 & 3 after a button press on the device.