### PR TITLE
Add fingerprint for Trust ZSDR-850

### DIFF
--- a/zigbee-smoke-detector-heiman/fingerprints.yml
+++ b/zigbee-smoke-detector-heiman/fingerprints.yml
@@ -14,6 +14,11 @@ zigbeeManufacturer:
     manufacturer: HEIMAN
     model: SmokeSensor-EM
     deviceProfileName: smoke-battery
+  - id: "Trust/ZSDR-850"
+    deviceLabel: ZSDR-850 Smoke Detector
+    manufacturer: Trust
+    model: SmokeSensor-EM
+    deviceProfileName: smoke-battery
   - id: "HEIMAN/SmokeSensor-N-3.0"
     deviceLabel: HEIMAN Smoke Detector
     manufacturer: HEIMAN


### PR DESCRIPTION
This is a rebranded Heiman unit. The manufacturer on the box is "KlikAanKlikUit", but I believe that they acquired Trust and I think the shorter brand name works better here.