### PR TITLE
Add DAWON battery gas valve

### DIFF
--- a/zigbee-valve-st-mc/fingerprints.yml
+++ b/zigbee-valve-st-mc/fingerprints.yml
@@ -34,6 +34,11 @@ zigbeeManufacturer :
     manufacturer: Compacta
     model: ZBVC1(1023A)
     deviceProfileName: valve-battery-powerSource
+  - id: "GasValve/SG-V100-ZB"
+    deviceLabel: Dawon Valve
+    manufacturer: DAWON_DNS
+    model: SG-V100-ZB
+    deviceProfileName: valve-battery-powerSource
   - id: "Valve/TS0011"
     deviceLabel: Water Valve
     manufacturer: _TYZB01_rifa0wlb


### PR DESCRIPTION
Add fingerprint of device following standard ZigBee valve protocol.

## DAWON DNS Gas Valve
| | |
|---|---|
| manufacturer | DAWON_DNS |
| model | SG-V100-ZB |
| powerSource | battery |

https://pmshop.co.kr/product/iot-%EC%8A%A4%EB%A7%88%ED%8A%B8-%EA%B0%80%EC%8A%A4%EB%9D%BD-%EA%B0%80%EC%8A%A4%EC%B0%A8%EB%8B%A8%EA%B8%B0/122/

![image](https://user-images.githubusercontent.com/1617368/216116516-76795c8b-3d06-4837-9337-7add8da71db5.png)
