### PR TITLE
Add Sengled E1F-N9G

### DIFF
--- a/zigbee-light-multifunction-v6/fingerprints.yml
+++ b/zigbee-light-multifunction-v6/fingerprints.yml
@@ -24,6 +24,11 @@ zigbeeManufacturer:
     manufacturer: sengled
     model: E11-G13
     deviceProfileName: switch-level
+  - id: "Sengled/E1F-N9G"
+    deviceLabel: Sengled E1F-N9G
+    manufacturer: sengled
+    model: E1F-N9G
+    deviceProfileName: switch-level
   - id: "IKEA/Bulb E27 WW"
     deviceLabel: IKEA Bulb
     manufacturer: IKEA of Sweden


### PR DESCRIPTION
Added fingerprint for Sengled E1F-N9G

Tested as working against my Hub v2 and 2x E1F-N9G bulbs.