### PR TITLE
Added Support for LIDL Power Meter Plug - TS011F

### DIFF
--- a/zigbee-switch-power-v5/fingerprints.yml
+++ b/zigbee-switch-power-v5/fingerprints.yml
@@ -314,3 +314,8 @@ zigbeeManufacturer:
     manufacturer: _TZ3000_tgddllx4
     model: TS0001
     deviceProfileName: switch-power-energy-plug
+  - id: "_TZ3000_ynmowq/TS011F"
+    deviceLabel: TS011F Lidl Plug
+    manufacturer: _TZ3000_ynmowq
+    model: TS011F
+    deviceProfileName: switch-power-energy-plug

--- a/zigbee-switch-power-v5/fingerprints.yml
+++ b/zigbee-switch-power-v5/fingerprints.yml
@@ -314,8 +314,8 @@ zigbeeManufacturer:
     manufacturer: _TZ3000_tgddllx4
     model: TS0001
     deviceProfileName: switch-power-energy-plug
-  - id: "_TZ3000_ynmowq/TS011F"
+  - id: "_TZ3000_ynmowqk2/TS011F"
     deviceLabel: TS011F Lidl Plug
-    manufacturer: _TZ3000_ynmowq
+    manufacturer: _TZ3000_ynmowqk2
     model: TS011F
     deviceProfileName: switch-power-energy-plug


### PR DESCRIPTION
Hi, I just added a new device to the fingerprints file. It's for LIDL Power Meter Plug - TS011F. I tested it on my personal channel. It works correctly. 