### PR TITLE
Added Support for Perenio Leak Sensor - PECLS01

### DIFF
--- a/zigbee-moisture-sensor-v2/fingerprints.yml
+++ b/zigbee-moisture-sensor-v2/fingerprints.yml
@@ -109,3 +109,8 @@ zigbeeManufacturer:
     manufacturer: _TZ3000_d16y6col
     model: TS0207
     deviceProfileName: moisture-battery
+  - id: "PECLS01"
+    deviceLabel: PECLS01 Water Leak Sensor
+    manufacturer: Perenio
+    model: PECLS01
+    deviceProfileName: moisture-battery


### PR DESCRIPTION
Hey, I just added Support for Perenio Leak Sensor - PECLS01. I tested it on my Hub and it works correctly. Not sure about the battery if it's 100% accurate, but it looks correct.