### PR TITLE
Add QS-Zigbee-D02-TRIAC-2C-L module (dual dimmer)

### DIFF
--- a/zigbee-multi-switch-v4.5-childs-edge/fingerprints.yml
+++ b/zigbee-multi-switch-v4.5-childs-edge/fingerprints.yml
@@ -912,3 +912,8 @@ zigbeeManufacturer:
     manufacturer: Interfree
     model: IDSW2O
     deviceProfileName: two-switch-level
+  - id: "TS110F/_TZ3000_92chsky7"
+    deviceLabel: QS-Zigbee-D02-TRIAC-2C-L
+    manufacturer: _TZ3000_92chsky7
+    model: TS110F
+    deviceProfileName: two-switch-level


### PR DESCRIPTION
Dual no-neutral dimmer module sold on AliExpress. Works correctly in my local installation (applied on top of 51cd03a2650251e3a4ccd3f39d4bdcf15fcc936f as the current code does not compile).