### PR TITLE
Add new Lock Yale Brazil model LIA

### DIFF
--- a/zigbee-lock-mc/fingerprints.yml
+++ b/zigbee-lock-mc/fingerprints.yml
@@ -1,5 +1,10 @@
 zigbeeManufacturer:
   # YALE
+  - id: "Yale Lia"
+    deviceLabel: "Yale Door Lock"
+    manufacturer: Yale
+    model: LIA
+    deviceProfileName: base-lock
   - id: "Yale YRD220/240"
     deviceLabel: "Yale Door Lock"
     manufacturer: Yale


### PR DESCRIPTION
New modelo YALE Brasil
Model: Lia
Zigbee
-Ep: 0x01={ 0000,0004,0003,100F,0101 }
FingerPrinted_EndOPoint.Id: 0x01
App Version: 0x01, ZCL Version: 0x02